### PR TITLE
Improved async tests syntax

### DIFF
--- a/tests/unit/coverageReport/LCOVCoverageReport.spec.js
+++ b/tests/unit/coverageReport/LCOVCoverageReport.spec.js
@@ -3,19 +3,15 @@ import parsedLcov from '../../mocks/parse-lcov';
 
 describe('lcov coverage report', () => {
   test('should raise an error in file does not exists', async () => {
-    try {
-      await LCOVCoverageReport.build('testPath/example.json');
-    } catch (error) {
-      expect(error).toStrictEqual(new Error('coverage report does not exists, check path'));
-    }
+    expect(LCOVCoverageReport.build('testPath/example.json'))
+      .resolves
+      .toThrowError('coverage report does not exists, check path');
   });
 
   test('should raise an error in file has corrupted content', async () => {
-    try {
-      await LCOVCoverageReport.build('tests/mocks/invalid-lcov.info');
-    } catch (error) {
-      expect(error).toStrictEqual('Failed to parse string');
-    }
+    expect(LCOVCoverageReport.build('tests/mocks/invalid-lcov.info'))
+      .resolves
+      .toThrowError('Failed to parse string');
   });
 
   test('should parse report content', async () => {


### PR DESCRIPTION
Looks like a couple of async tests were using a try-catch block to verify an error.

jest already offers a native way to test whether a promise will return an error, I think using the native syntax is a better approach as it also uniforms with the other tests :)